### PR TITLE
The system command is coughing up errors, the syntax isn't right for the...

### DIFF
--- a/lib/chess/gnuchess.rb
+++ b/lib/chess/gnuchess.rb
@@ -103,7 +103,7 @@ module Chess
 
     # Return true if Gnuchess is installed, false otherwise.
     def self.gnuchess_installed?
-      system('which gnuchess >& /dev/null')
+      system('which gnuchess > /dev/null 2>&1')
       $?.exitstatus == 0
     end
 


### PR DESCRIPTION
... latest ubuntu/bash install.

[4] pry(main)> g.extend Chess::Gnuchess
sh: 1: Syntax error: Bad fd number
RuntimeError: You need to install Gnuchess to use the module Chess::Gnuchess.

This change fixes that.
