### PR TITLE
Allocating an extra byte for string termination in print_board

### DIFF
--- a/ext/board.c
+++ b/ext/board.c
@@ -53,7 +53,7 @@ set_occupied (Board *board)
 char*
 print_board (Board *board)
 {
-  char *s = (char *) malloc (250);
+  char *s = (char *) malloc (251);
   int si = 0;
   int i, j;
   for (i = 7; i >= 0; i--) // rank => top to bottom


### PR DESCRIPTION
For issue #4

The board text is 250 characters, which doesn't leave room for null termination. I can't think of any way to test this, but the numbers all seem to add up.
