### PR TITLE
fixed fen load winner check

### DIFF
--- a/ext/game.c
+++ b/ext/game.c
@@ -327,7 +327,12 @@ set_fen (Game *g, const char *fen)
 
   // check result
   if (king_in_checkmate (board, board->active_color))
-    g->result = board->active_color;
+    {
+      if (board->active_color)
+        g->result = WHITE_WON;
+      else
+        g->result = BLACK_WON;
+    }
   else
     if (stalemate (board, board->active_color) || insufficient_material (board))
       g->result = DRAW;

--- a/test/test_load_fen.rb
+++ b/test/test_load_fen.rb
@@ -11,13 +11,13 @@ class ChessTest < Minitest::Test
     assert_equal :in_progress, g.status
   end
 
-  def test_fen_white_won
+  def test_fen_black_won
     g = Chess::Game.load_fen('rnb1kbnr/pppp1ppp/4p3/8/5PPq/8/PPPPP2P/RNBQKBNR w KQkq - 1 3')
     assert_equal 'q', g.board['h4']
     assert_equal 'P', g.board['f4']
     assert_equal 'p', g.board[44]
-    assert_equal '1-0', g.result
-    assert_equal :white_won, g.status
+    assert_equal '0-1', g.result
+    assert_equal :black_won, g.status
   end
 
   def test_fen_stalemate


### PR DESCRIPTION
Hey, so in further retrospect, it looks that when loading a FEN, the winner of the game is the opposite of the boards active color. 

For example, the test case:
```
rnb1kbnr/pppp1ppp/4p3/8/5PPq/8/PPPPP2P/RNBQKBNR w KQkq - 1 3
```
The active color is w, but the winner is actually black. You can see the game [here](http://www.chessgames.com/perl/chessgame?gid=1251128). Let me know if you see anything wrong with this!