### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/chess.gemspec
+++ b/chess.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.description = 'A fast chess library that use bitboards to play chess with Ruby.'
   s.license     = 'LGPLv3'
 
-  s.rubyforge_project = 'chess'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.